### PR TITLE
Fix detour on popups

### DIFF
--- a/lua/detour/util.lua
+++ b/lua/detour/util.lua
@@ -41,4 +41,9 @@ function M.is_floating(window_id)
     return vim.api.nvim_win_get_config(window_id).relative ~= ''
 end
 
+-- Returns the zindex for the given window, if floating, otherwise nil.
+function M.get_maybe_zindex(window_id)
+    return vim.api.nvim_win_get_config(window_id).zindex
+end
+
 return M

--- a/spec/detour_spec.lua
+++ b/spec/detour_spec.lua
@@ -65,8 +65,27 @@ describe("detour", function ()
             {relative='win', width=12, height=3, bufpos={100,10}}
         )
 
-        -- TODO: correct this behavior.
-        assert.has.errors(detour.Detour)
+        local parent_popup = vim.api.nvim_get_current_win()
+        local parent_buffer = vim.api.nvim_get_current_buf()
+        assert.True(util.is_floating(parent_popup))
+        local parent_config = vim.api.nvim_win_get_config(parent_popup)
+
+        detour.Detour()
+        local child_popup = vim.api.nvim_get_current_win()
+        assert.True(util.is_floating(child_popup))
+        local child_config = vim.api.nvim_win_get_config(child_popup)
+        local child_buffer = vim.api.nvim_get_current_buf()
+        -- The nested popup should always be on top of the parent popup
+        assert.True(child_config.zindex > parent_config.zindex)
+
+        assert.same(#vim.api.nvim_list_wins(), 3)
+        assert.same(base_buffer, parent_buffer)
+        assert.same(parent_buffer, child_buffer)
+
+        vim.cmd.quit()
+        assert.same(#vim.api.nvim_list_wins(), 2)
+        vim.cmd.quit()
+        assert.same(#vim.api.nvim_list_wins(), 1)
     end)
     -- TODO: technically, either all test cases involving nested popups need to be tested with both
     -- nested Detour popups and nested windows generally, or we need to both those objects behave

--- a/spec/detour_spec.lua
+++ b/spec/detour_spec.lua
@@ -45,6 +45,7 @@ describe("detour", function ()
         end
     end)
 
+    -- See Issue #25 for a discussion of duplication in this test suite.
     it("create popup", function ()
         vim.cmd.view("/tmp/detour")
         local before_buffer = vim.api.nvim_get_current_buf()
@@ -66,8 +67,7 @@ describe("detour", function ()
             {relative='win', width=12, height=3, bufpos={100,10}}
         )
 
-        -- this is all copied from the test case below; see the note which follows this function for
-        -- a note regarding how these tests could be cleaned up.
+        -- See the note above regarding the duplication of this test code.
         local parent_popup = vim.api.nvim_get_current_win()
         local parent_buffer = vim.api.nvim_get_current_buf()
         assert.True(util.is_floating(parent_popup))
@@ -90,15 +90,6 @@ describe("detour", function ()
         vim.cmd.quit()
         assert.same(#vim.api.nvim_list_wins(), 1)
     end)
-    -- TODO: technically, either 
-    --   1) all test cases involving nested popups need to be tested with both
-    --      nested Detour popups and nested windows generally; or
-    --   2) we must ensure that detour.Detour() behaves identically when nesting over either of the
-    --      objects just mentioned.
-    -- Approach (2) is clearly superior, but it's not clear (to neilvyas) how to accomplish that;
-    -- as such, perhaps the better approach is to abstract all nesting-related coverage into a
-    -- function which accepts a "popup constructor" and produces test cases, then invoke this
-    -- function twice, once with a constructor for detour.Detour() and another for general popups.
     
     -- TODO: Make sure popups are fully contained within their parents
     it("create nested popup", function ()

--- a/spec/detour_spec.lua
+++ b/spec/detour_spec.lua
@@ -44,6 +44,7 @@ describe("detour", function ()
             end
         end
     end)
+
     it("create popup", function ()
         vim.cmd.view("/tmp/detour")
         local before_buffer = vim.api.nvim_get_current_buf()
@@ -65,6 +66,8 @@ describe("detour", function ()
             {relative='win', width=12, height=3, bufpos={100,10}}
         )
 
+        -- this is all copied from the test case below; see the note which follows this function for
+        -- a note regarding how these tests could be cleaned up.
         local parent_popup = vim.api.nvim_get_current_win()
         local parent_buffer = vim.api.nvim_get_current_buf()
         assert.True(util.is_floating(parent_popup))
@@ -87,9 +90,15 @@ describe("detour", function ()
         vim.cmd.quit()
         assert.same(#vim.api.nvim_list_wins(), 1)
     end)
-    -- TODO: technically, either all test cases involving nested popups need to be tested with both
-    -- nested Detour popups and nested windows generally, or we need to both those objects behave
-    -- identically.
+    -- TODO: technically, either 
+    --   1) all test cases involving nested popups need to be tested with both
+    --      nested Detour popups and nested windows generally; or
+    --   2) we must ensure that detour.Detour() behaves identically when nesting over either of the
+    --      objects just mentioned.
+    -- Approach (2) is clearly superior, but it's not clear (to neilvyas) how to accomplish that;
+    -- as such, perhaps the better approach is to abstract all nesting-related coverage into a
+    -- function which accepts a "popup constructor" and produces test cases, then invoke this
+    -- function twice, once with a constructor for detour.Detour() and another for general popups.
     
     -- TODO: Make sure popups are fully contained within their parents
     it("create nested popup", function ()

--- a/spec/detour_spec.lua
+++ b/spec/detour_spec.lua
@@ -57,6 +57,21 @@ describe("detour", function ()
         assert.same(#vim.api.nvim_list_wins(), 2)
     end)
 
+    it("create nested popup over non-Detour popup", function ()
+        local base_buffer = vim.api.nvim_get_current_buf()
+        local non_detour_popup = vim.api.nvim_open_win(
+            vim.api.nvim_win_get_buf(0),
+            true,
+            {relative='win', width=12, height=3, bufpos={100,10}}
+        )
+
+        -- TODO: correct this behavior.
+        assert.has.errors(detour.Detour)
+    end)
+    -- TODO: technically, either all test cases involving nested popups need to be tested with both
+    -- nested Detour popups and nested windows generally, or we need to both those objects behave
+    -- identically.
+    
     -- TODO: Make sure popups are fully contained within their parents
     it("create nested popup", function ()
         local base_buffer = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
Fixes #21 

NOTE: the docker setup didn't work for me, so I had to spend a little time hacking around to get it to work.

Also, lua... seems really annoying to work with? it keeps editing my .gitignore to add /lua, which means that the actual plugin files are ignored. Plus, the last step of the dockerfile, RUN luarocks install, doesn't seem to actually install busted, hence why I had to do it in the script; I think this is because of how volume mounting works in docker. Dunno, been years since I've used it.

This should probably not be left in as a commit, and should be corrected separately, but I'm not going to get to that out. If an dwhen we decide to merge this, we can leave this commit out.

Anyway, I've corrected the issue and added test coverage. The test coverage is not to my satisfaction, but I'm not going to try to fix it at the moment, given that I'd have to learn how busted and testing generally works in lua; as such, I've left a helpful note.