### PR TITLE
Feat: Added Example for Implementing `:h` with Detour

### DIFF
--- a/examples/help-float.md
+++ b/examples/help-float.md
@@ -1,0 +1,51 @@
+# Display help files in a Detour window
+Here are two examples of displaying help files in a Detour popup window without it
+opening a split window.
+
+### Creating a User Command
+Opening a help file via a custom user command
+```lua
+vim.api.nvim_create_user_command("H", function (args)
+    local file = args.args
+    vim.cmd.h(file)
+    local help_win = vim.api.nvim_get_current_win()
+
+    local ok = require('detour').Detour()
+    if ok then
+        vim.api.nvim_win_close(help_win, false)
+    end
+end, { nargs = 1 })
+```
+> Note: The downside to a custom User Command is that you do not get the autocomplete
+>       you would get with `:h` if you have nvim-cmp setup
+
+### Creating an Auto Command
+Opening a help file via `autocmd`
+```lua
+vim.api.nvim_create_autocmd("BufWinEnter", {
+    pattern = "*",
+    callback = function(event)
+        local filetype = vim.bo[event.buf].filetype
+        local file_path = event.match
+
+        if file_path:match "/doc/" ~= nil then
+            -- Only run if the filetype is a help file
+            if filetype == "help" or filetype == "markdown" then
+                -- Get the newly opened help window
+                -- and attempt to open a Detour() float
+                local help_win = vim.api.nvim_get_current_win()
+                local ok = require("detour").Detour()
+
+                -- If we successfully create a float of the help file
+                -- Close the split
+                if ok then
+                    vim.api.nvim_win_close(help_win, false)
+                end
+            end
+        end
+    end,
+})
+```
+> Note: This allows you to use `:h` and still get the autocompletion for docs
+>       if you have nvim-cmp setup.
+

--- a/lua/detour/init.lua
+++ b/lua/detour/init.lua
@@ -1,8 +1,8 @@
 local M = {}
 
 local util = require('detour.util')
-local MIN_POPUP_HEIGHT = 3 -- border (2) + text (1)
-local MIN_POPUP_WIDTH = 3 -- border (2) + text (1)
+local MIN_POPUP_HEIGHT = 1 -- border (2) + text (1)
+local MIN_POPUP_WIDTH = 1 -- border (2) + text (1)
 
 local internal = require('detour.internal')
 
@@ -87,7 +87,6 @@ local function construct_window_opts(coverable_windows, tab_id)
             table.insert(roots, window_id)
         end
     end
-    --print("window_ids " .. vim.inspect(window_ids))
 
     local uncoverable_windows = {}
     for _, root in ipairs(roots) do
@@ -95,7 +94,6 @@ local function construct_window_opts(coverable_windows, tab_id)
             table.insert(uncoverable_windows, root)
         end
     end
-    --print("uncoverable_windows " .. vim.inspect(uncoverable_windows))
     local horizontals = {}
     local verticals = {}
 
@@ -188,8 +186,8 @@ local function construct_window_opts(coverable_windows, tab_id)
         relative = "editor",
         row = top,
         col = left,
-        width = width - 2, -- create some space for borders
-        height = height - 2, -- create some space for borders
+        width = (width - 2 > 0) and (width - 2) or width, -- create some space for borders
+        height = (height - 2 > 0) and (height - 2) or height, -- create some space for borders
         border = "rounded",
         zindex = 1,
     }


### PR DESCRIPTION
Adds two examples one via a User command like you originally had given an example of and one via `autocmd`. Let me know if there is wording or anything you want me to change